### PR TITLE
Add Nominativ for edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ The command
 
     npm run compile
 
-compiles the .coffee files and moves them into the dist folder
+compiles the .coffee files and moves them into the dist folder. To upload to Google App store:
+
+- increment the version number in `dist/manifest.json`
+- zip the contents of the dist folder
+- upload
+
 
 #### Tests
 

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Neutrominator",
   "description": "Konvertiert Formen mit *innen und _innen u.ä. ins gewöhnliche Neutrum",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "permissions": [
     "activeTab",
     "storage"

--- a/dist/neutrominator.js
+++ b/dist/neutrominator.js
@@ -115,11 +115,11 @@ return /******/ (function(modules) { // webpackBootstrap
 	      lang = languagePrefixes[i];
 	      this.replaceIt(new RegExp(lang + "[\*_]innen", "g"), lang + "en");
 	    }
-	    this.replaceIt(/den ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen([a-z])/g, "den $1en $2er$3");
-	    this.replaceIt(/den ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen/g, "den $1en $2ern");
-	    this.replaceIt(/den ([a-zA-Z]*)en ([\s\S]*)r[\*_]innen/g, "den $1en $2ren");
+	    this.replaceIt(/(\sd|D)en ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen([a-z])/g, "$1en $2en $3er$4");
+	    this.replaceIt(/(\sd|D)en ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen/g, "$1en $2en $3ern");
+	    this.replaceIt(/(\sd|D)en ([a-zA-Z]*)en ([\s\S]*)r[\*_]innen/g, "$1en $2en $3ren");
 	    this.replaceIt(/die ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen/g, "die $1en $2er");
-	    this.replaceIt(/den ([a-zA-Z]*)er[\*_]innen/g, "den $1ern");
+	    this.replaceIt(/(\sd|D)en ([a-zA-Z]*)er[\*_]innen/g, "$1en $2ern");
 	    this.replaceIt(/or[\*_]innen/g, "oren");
 	    this.replaceIt(/er[\*_]innen/g, "er");
 	    this.replaceIt(/([gtd])[\*_]innen/g, "$1en");

--- a/src/neutrominator.coffee
+++ b/src/neutrominator.coffee
@@ -25,11 +25,11 @@ class Neutrominator
   parseAndRewriteStrict: ->
     for lang in languagePrefixes
       @replaceIt new RegExp( lang + "[\*_]innen", "g" ), lang + "en"
-    @replaceIt /den ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen([a-z])/g, "den $1en $2er$3"
-    @replaceIt /den ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen/g, "den $1en $2ern"
-    @replaceIt /den ([a-zA-Z]*)en ([\s\S]*)r[\*_]innen/g, "den $1en $2ren"
+    @replaceIt /(\sd|D)en ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen([a-z])/g, "$1en $2en $3er$4"
+    @replaceIt /(\sd|D)en ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen/g, "$1en $2en $3ern"
+    @replaceIt /(\sd|D)en ([a-zA-Z]*)en ([\s\S]*)r[\*_]innen/g, "$1en $2en $3ren"
     @replaceIt /die ([a-zA-Z]*)en ([a-zA-Z]*)er[\*_]innen/g, "die $1en $2er"
-    @replaceIt /den ([a-zA-Z]*)er[\*_]innen/g, "den $1ern"
+    @replaceIt /(\sd|D)en ([a-zA-Z]*)er[\*_]innen/g, "$1en $2ern"
     @replaceIt /or[\*_]innen/g, "oren"
     @replaceIt /er[\*_]innen/g, "er"
     @replaceIt /([gtd])[\*_]innen/g, "$1en"

--- a/test/neutrominator_spec.coffee
+++ b/test/neutrominator_spec.coffee
@@ -95,10 +95,10 @@ describe 'Neutrominator', ->
       cleanser.parseAndRewriteStrict()
       expect(element.innerHTML).toEqual 'Programmierer'
 
-    it 'creates correct Dativ for den Programmierer*innen', ->
-      element.innerHTML = 'den Programmierer*innen'
+    it 'creates correct Dativ for Den Programmierer*innen', ->
+      element.innerHTML = 'Den Programmierer*innen'
       cleanser.parseAndRewriteStrict()
-      expect(element.innerHTML).toEqual 'den Programmierern'
+      expect(element.innerHTML).toEqual 'Den Programmierern'
 
     it 'creates correct form for Buchhalter*innen', ->
       element.innerHTML = 'Buchhalter*innen'
@@ -110,10 +110,10 @@ describe 'Neutrominator', ->
       cleanser.parseAndRewriteStrict()
       expect(element.innerHTML).toEqual 'Kollegen'
 
-    it 'creates correct dativ form for "den meisten Buchhalter*innen"', ->
-      element.innerHTML = 'den meisten Buchhalter*innen'
+    it 'creates correct dativ form for " den meisten Buchhalter*innen"', ->
+      element.innerHTML = ' den meisten Buchhalter*innen'
       cleanser.parseAndRewriteStrict()
-      expect(element.innerHTML).toEqual 'den meisten Buchhaltern'
+      expect(element.innerHTML).toEqual ' den meisten Buchhaltern'
 
     it 'creates correct Nominativ for "die meisten Buchhalter*innen"', ->
       element.innerHTML = 'die meisten Buchhalter*innen'
@@ -121,9 +121,9 @@ describe 'Neutrominator', ->
       expect(element.innerHTML).toEqual 'die meisten Buchhalter'
 
     it 'creates correct Dativ for "den meisten Buchhalter*innen und Sekretär*innen"', ->
-      element.innerHTML = 'den meisten Buchhalter*innen und Sekretär*innen'
+      element.innerHTML = ' den meisten Buchhalter*innen und Sekretär*innen'
       cleanser.parseAndRewriteStrict()
-      expect(element.innerHTML).toEqual 'den meisten Buchhaltern und Sekretären'
+      expect(element.innerHTML).toEqual ' den meisten Buchhaltern und Sekretären'
 
     it 'creates correct Helfer', ->
       element.innerHTML = 'kamen Helfer*innen von'
@@ -134,10 +134,16 @@ describe 'Neutrominator', ->
       element.innerHTML = 'ihren Chef*innen'
       cleanser.parseAndRewriteStrict()
       expect(element.innerHTML).toEqual 'ihren Chefs'
+
     it 'creates correct Zuschauersitzen', ->
       element.innerHTML = 'in den gepolsterten Zuschauer*innensitzen'
       cleanser.parseAndRewriteStrict()
       expect(element.innerHTML).toEqual 'in den gepolsterten Zuschauersitzen'
+
+    it 'creates correct Zuschauersitzen', ->
+      element.innerHTML = 'Den gepolsterten Zuschauer*innensitzen'
+      cleanser.parseAndRewriteStrict()
+      expect(element.innerHTML).toEqual 'Den gepolsterten Zuschauersitzen'
 
     it 'creates correct die künstlerischen Leiter', ->
       element.innerHTML = 'Danach stehen die künstlerischen Leiter*innen von Bühnenbild, Kostümen, Musik, Video etc., die an ihre Assistent*innen delegieren, die wiederum mit den Hospitant*innen kommunizieren.'
@@ -170,6 +176,10 @@ describe 'Neutrominator', ->
       cleanser.parseAndRewriteStrict()
       expect(element.innerHTML).toEqual 'Was wäre, wenn in der Kulturbranche einer. mehr unbezahlte Praktika machen würde?'
 
+    it 'creates correct Nominativ for combo Eingeladen waren Vertreter', ->
+      element.innerHTML = 'Eingeladen waren Vertreter*innen des Justizministeriums'
+      cleanser.parseAndRewriteStrict()
+      expect(element.innerHTML).toEqual 'Eingeladen waren Vertreter des Justizministeriums'
 
 
 


### PR DESCRIPTION
„Eingeladen waren Vertreter*innen“ was deemed Dativ resulting "Eingeladen waren Vertetern". In this PR the RegExp was updated to only match segments beginning with article „ den“ or „Den“ to
the Dativ form.